### PR TITLE
Commit to match first few link changes

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -29,6 +29,10 @@ RedirectMatch 302 \
 	https://forums.classicpress.net/c/support/security-page
 
 RedirectMatch 302 \
+	^/announcements/release-notes \
+	https://forums.classicpress.net/c/announcements/release-notes
+
+RedirectMatch 302 \
 	^/updating-classicpress/?$ \
 	https://docs.classicpress.net/updating-classicpress/
 

--- a/.htaccess
+++ b/.htaccess
@@ -9,6 +9,10 @@ RedirectMatch 302 \
 	https://forums.classicpress.net/c/team-discussions/classicpress-security
 
 RedirectMatch 302 \
+	^/faq-support/
+	https://link.classicpress.net/faq-support/
+
+RedirectMatch 302 \
 	^/plugin-compatibility/?$ \
 	https://docs.classicpress.net/faq-support/#will-my-current-plugins-and-themes-work-in-classicpress
 
@@ -29,9 +33,9 @@ RedirectMatch 302 \
 	https://docs.classicpress.net/updating-classicpress/
 
 RedirectMatch 302 \
-	^installing-classicpress/#installation-step \
+	^installing-classicpress/installation-step \
 	https://docs.classicpress.net/installing-classicpress/#installation-step
 
 RedirectMatch 302 \
-	^testing-classicpress/#reporting-bugs \
+	^testing-classicpress/reporting-bugs \
 	https://docs.classicpress.net/testing-classicpress/#reporting-bugs

--- a/.htaccess
+++ b/.htaccess
@@ -37,13 +37,21 @@ RedirectMatch 302 \
 	https://forums.classicpress.net/c/announcements/release-notes
 
 RedirectMatch 302 \
+	^/classicpress-1-0-0-aurora-release-notes \
+	https://forums.classicpress.net/t/classicpress-1-0-0-aurora-release-notes/910
+
+RedirectMatch 302 \
 	^/updating-classicpress/?$ \
 	https://docs.classicpress.net/updating-classicpress/
 
 RedirectMatch 302 \
-	^installing-classicpress/installation-step \
+	^/installing-classicpress/installation-step \
 	https://docs.classicpress.net/installing-classicpress/#installation-step
 
 RedirectMatch 302 \
-	^testing-classicpress/reporting-bugs \
+	^/testing-classicpress/reporting-bugs \
 	https://docs.classicpress.net/testing-classicpress/#reporting-bugs
+
+RedirectMatch 302 \
+	^/petitions \
+	https://petitions.classicpress.net/

--- a/.htaccess
+++ b/.htaccess
@@ -25,6 +25,10 @@ RedirectMatch 302 \
 	https://docs.classicpress.net/developing-classicpress/security-page/#contacting-plugin-authors
 
 RedirectMatch 302 \
+	^/support/ \
+	https://forums.classicpress.net/c/support/
+
+RedirectMatch 302 \
 	^/support/security-page/?$ \
 	https://forums.classicpress.net/c/support/security-page
 

--- a/.htaccess
+++ b/.htaccess
@@ -17,6 +17,10 @@ RedirectMatch 302 \
 	https://docs.classicpress.net/faq-support/#will-my-current-plugins-and-themes-work-in-classicpress
 
 RedirectMatch 302 \
+	^/docs \
+	https://docs.classicpress.net
+
+RedirectMatch 302 \
 	^/security-page/?$ \
 	https://docs.classicpress.net/developing-classicpress/security-page/
 

--- a/.htaccess
+++ b/.htaccess
@@ -23,3 +23,15 @@ RedirectMatch 302 \
 RedirectMatch 302 \
 	^/support/security-page/?$ \
 	https://forums.classicpress.net/c/support/security-page
+
+RedirectMatch 302 \
+	^/updating-classicpress/?$ \
+	https://docs.classicpress.net/updating-classicpress/
+
+RedirectMatch 302 \
+	^installing-classicpress/#installation-step \
+	https://docs.classicpress.net/installing-classicpress/#installation-step
+
+RedirectMatch 302 \
+	^testing-classicpress/#reporting-bugs \
+	https://docs.classicpress.net/testing-classicpress/#reporting-bugs


### PR DESCRIPTION
This PR is required to enable a PR for moving URLs to use the `link` subdomain in the main ClassicPress code:
https://github.com/ClassicPress/ClassicPress/pull/516