### PR TITLE
Add links for "the-cms-for-creators" and "releases"

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -23,3 +23,11 @@ RedirectMatch 302 \
 RedirectMatch 302 \
 	^/support/security-page/?$ \
 	https://forums.classicpress.net/c/support/security-page
+
+RedirectMatch 302 \
+	^/releases/?$ \
+	https://forums.classicpress.net/c/announcements/release-notes
+
+RedirectMatch 302 \
+	^/the-cms-for-creators/?$ \
+	https://www.classicpress.net


### PR DESCRIPTION
## Background

This PR adds new placeholder links for `the-cms-for-creators` and `releases`.

The `the-cms-for-creators` link was first mentioned here: https://github.com/ClassicPress/ClassicPress/pull/654#discussion_r576266858

The `releases` link was first mentioned here: https://github.com/ClassicPress/ClassicPress/pull/654#issuecomment-787451082

## Type of change

Adds two new `302` rules to `.htaccess`

## Result

https://link.classicpress.net/the-cms-for-creators will be redirected to https://www.classicpress.net
https://link.classicpress.net/releases will be redirected to https://forums.classicpress.net/c/announcements/release-notes
