### PR TITLE
Add and update miscellaneous links

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,7 +6,7 @@ RedirectMatch 302 \
 
 RedirectMatch 302 \
 	^/forum/security/?$ \
-https://forums.classicpress.net/c/projects/core-development/18
+	https://forums.classicpress.net/c/projects/core-development/18
 
 RedirectMatch 302 \
 	^/plugin-compatibility/?$ \
@@ -38,4 +38,4 @@ RedirectMatch 302 \
 
 RedirectMatch 302 \
 	^/core-privacy-policy/?$ \
-	https://www.classicpress.net/privacy-policy
+	https://www.classicpress.net/privacy-policy/#core-privacy-policy

--- a/.htaccess
+++ b/.htaccess
@@ -6,11 +6,11 @@ RedirectMatch 302 \
 
 RedirectMatch 302 \
 	^/forum/security/?$ \
-	https://forums.classicpress.net/c/team-discussions/classicpress-security
+	https://forums.classicpress.net/c/general-discussion/security-news/45
 
 RedirectMatch 302 \
 	^/plugin-compatibility/?$ \
-	https://docs.classicpress.net/faq-support/#will-my-current-plugins-and-themes-work-in-classicpress
+	https://docs.classicpress.net/user-guides/faq-and-support/#will-my-current-plugins-and-themes-work-in-classicpress
 
 RedirectMatch 302 \
 	^/security-page/?$ \
@@ -22,7 +22,7 @@ RedirectMatch 302 \
 
 RedirectMatch 302 \
 	^/support/security-page/?$ \
-	https://forums.classicpress.net/c/support/security-page
+	https://forums.classicpress.net/c/general-discussion/security-news/45
 
 RedirectMatch 302 \
 	^/releases/?$ \
@@ -31,3 +31,11 @@ RedirectMatch 302 \
 RedirectMatch 302 \
 	^/the-cms-for-creators/?$ \
 	https://www.classicpress.net
+
+RedirectMatch 302 \
+	^/core-privacy-policy/?$ \
+	https://www.classicpress.net/privacy-policy
+	
+RedirectMatch 302 \
+	^/docs/custom-login-image/?$ \
+	https://docs.classicpress.net/user-guides/custom-login-image/


### PR DESCRIPTION
I have never done this before, I hope that I am following all etiquette correctly.

**Background**
Adding two new placeholder links for core-privacy-policy and custom-login-image.

The core-privacy-policy link was discussed here: https://github.com/ClassicPress/subdomain-link/issues/2
Note: On line 51 of freedoms.php where core-privacy-policy link is used, the link has a "trailing slash" and may need to be editted?

Editing three bad placeholder redirects - two due to Forum reorganization, one due to new Docs Hub
There is only one security forum (security news), so both security forum links will point to that. https://link.classicpress.net/forum/security and https://link.classicpress.net/support/security-page


**Type of change**
Adds two new 302 rules to .htaccess
Edits three existing 302 rules in .htaccess

**Result**
https://link.classicpress.net/core-privacy-policy/ will be redirected to https://www.classicpress.net/privacy-policy

https://link.classicpress.net/docs/custom-login-image will be redirected to https://docs.classicpress.net/user-guides/custom-login-image/

https://link.classicpress.net/forum/security will be redirected to https://forums.classicpress.net/c/general-discussion/security-news/45

https://link.classicpress.net/plugin-compatibility  will be redirected to https://docs.classicpress.net/user-guides/faq-and-support/#will-my-current-plugins-and-themes-work-in-classicpress

https://link.classicpress.net/support/security-page will be redirected to https://forums.classicpress.net/c/general-discussion/security-news/45
